### PR TITLE
Refactor OpenApiMultiFileReader to return ReadResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ An OpenAPI reader that merges external references into a single document using t
 The class `OpenApiMultiFileReader` is used to load an OpenAPI specifications document file locally or remotely using a YAML or JSON file. `OpenApiMultiFileReader` will automatically merge external references if the OAS file uses them. Merging external referenecs that the file is in the same folder as the main OAS file. When loading OAS files remotely, the external references must also be remote files. Currently, you can not load a remote OAS file that has external references to local files. 
 
 ```csharp
-OpenApiDocument document = await OpenApiMultiFileReader.Read("petstore.yaml");
+ReadResult result = await OpenApiMultiFileReader.Read("petstore.yaml");
+OpenApiDocument document = result.OpenApiDocument;
 ```
 
 In the example above, we have OpenAPI specifications that are split into multiple documents. **`petstore.yaml`** contains the **`paths`** and **`petstore.components.yaml`** contain the **`components/schemas`**

--- a/src/OasReader.Tests/OpenApiReaderTests.cs
+++ b/src/OasReader.Tests/OpenApiReaderTests.cs
@@ -12,7 +12,7 @@ public class OpenApiReaderTests
     [InlineData("petstore.yaml", "petstore.components.yaml")]
     public async Task Returns_NotNull(string apiFile, string componentsFile)
     {
-        OpenApiDocument result = await Arrange(apiFile, componentsFile);
+        var result = await Arrange(apiFile, componentsFile);
         result.Should().NotBeNull();
     }
 
@@ -68,6 +68,6 @@ public class OpenApiReaderTests
         await File.WriteAllTextAsync(componentsFilename, componentContents);
         await File.WriteAllTextAsync(openapiFilename, apiContents);
 
-        return await OpenApiMultiFileReader.Read(openapiFilename);
+        return (await OpenApiMultiFileReader.Read(openapiFilename)).OpenApiDocument;
     }
 }

--- a/src/OasReader/OpenApiMultiFileReader.cs
+++ b/src/OasReader/OpenApiMultiFileReader.cs
@@ -6,7 +6,7 @@ namespace Microsoft.OpenApi.Readers;
 
 public static class OpenApiMultiFileReader
 {
-    public static async Task<OpenApiDocument> Read(string openApiFile, CancellationToken cancellationToken = default)
+    public static async Task<ReadResult> Read(string openApiFile, CancellationToken cancellationToken = default)
     {
         var directoryName = new FileInfo(openApiFile).DirectoryName;
         var openApiReaderSettings = new OpenApiReaderSettings
@@ -21,12 +21,16 @@ public static class OpenApiMultiFileReader
         var result = await streamReader.ReadAsync(stream, cancellationToken);
         var document = result.OpenApiDocument;
 
-        if (document.ContainsExternalReferences())
+        if (result.OpenApiDocument.ContainsExternalReferences())
         {
             document = document.MergeExternalReferences(openApiFile);
         }
 
-        return document ?? throw new InvalidOperationException($"Could not read the OpenAPI file at {openApiFile}");
+        return new ReadResult
+        {
+            OpenApiDiagnostic = result.OpenApiDiagnostic,
+            OpenApiDocument = document ?? throw new InvalidOperationException($"Could not read the OpenAPI file at {openApiFile}")
+        };
     }
 
     private static async Task<Stream> GetStream(string input)


### PR DESCRIPTION
This pull request refactors the `OpenApiMultiFileReader` class to return a `ReadResult` object instead of directly returning the `OpenApiDocument`. The `ReadResult` object contains both the `OpenApiDocument` and the `OpenApiDiagnostic` for better error handling and reporting. This change improves the readability and maintainability of the code.