### PR TITLE
Fix null reference exception in OpenApiDocumentExtensions.cs

### DIFF
--- a/src/OasReader/OpenApiDocumentExtensions.cs
+++ b/src/OasReader/OpenApiDocumentExtensions.cs
@@ -47,12 +47,12 @@ namespace Microsoft.OpenApi.Models
                 .Any(kvp => 
                     kvp.Value.Parameters.Any(
                         p => p.Reference?.IsExternal == true || 
-                        p.Schema.Reference?.IsExternal == true || 
+                        p.Schema?.Reference?.IsExternal == true || 
                         p.Content.Any(c => c.Value.Schema?.Reference?.IsExternal == true)) ||
                     kvp.Value.Operations.Any(
                         o => o.Value.Parameters.Any(p => 
                             p.Reference?.IsExternal == true || 
-                            p.Schema.Reference?.IsExternal == true || 
+                            p.Schema?.Reference?.IsExternal == true || 
                             p.Content.Any(c => c.Value.Schema?.Reference?.IsExternal == true)) ||
                         o.Value.RequestBody?.Content?.Any(c => c.Value.Schema?.Reference?.IsExternal == true) == true ||
                         o.Value.Responses.Any(r => 


### PR DESCRIPTION
This pull request fixes a null reference exception in the OpenApiDocumentExtensions.cs file. The exception occurred when accessing the Reference property of certain objects. This PR updates the code to handle null values properly, preventing the exception from occurring.