### PR TITLE
Add support for defining a ValidationRuleSet

### DIFF
--- a/src/OasReader.Tests/OpenApiDocumentExtensionsTests.cs
+++ b/src/OasReader.Tests/OpenApiDocumentExtensionsTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Validations;
 using Xunit;
 
 namespace OasReader.Tests;
@@ -89,5 +90,68 @@ public class OpenApiDocumentExtensionsTests
     {
         var sut = await OpenApiMultiFileReader.Read(url);
         sut.OpenApiDocument.ContainsExternalReferences().Should().BeFalse();
+    }
+    
+    [Theory]
+    [InlineData("v3.ingram-micro.json")]
+    [InlineData("v3.weather.json")]
+    public async Task ValidationRuleSet_Default(string apiFile)
+    {
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+
+        var openapiFilename = Path.Combine(folder, apiFile);
+        var apiContents = EmbeddedResources.GetStream(apiFile);
+        await File.WriteAllTextAsync(openapiFilename, apiContents);
+        
+        var result = await OpenApiMultiFileReader.Read(openapiFilename, ValidationRuleSet.GetDefaultRuleSet());
+
+        result.OpenApiDiagnostic.Errors.Should().NotBeEmpty();
+    }
+    
+    [Theory]
+    [InlineData("v2.api-with-examples.yaml")]
+    [InlineData("v2.petstore-expanded.yaml")]
+    [InlineData("v2.petstore-minimal.yaml")]
+    [InlineData("v2.petstore-simple.yaml")]
+    [InlineData("v2.petstore-with-external-docs.yaml")]
+    [InlineData("v2.petstore.yaml")]
+    [InlineData("v2.uber.yaml")]
+    [InlineData("v2.api-with-examples.json")]
+    [InlineData("v2.petstore-expanded.json")]
+    [InlineData("v2.petstore-minimal.json")]
+    [InlineData("v2.petstore-simple.json")]
+    [InlineData("v2.petstore-with-external-docs.json")]
+    [InlineData("v2.petstore.json")]
+    [InlineData("v2.uber.json")]
+    [InlineData("v3.api-with-examples.yaml")]
+    [InlineData("v3.api-with-examples.json")]
+    [InlineData("v3.callback-example.yaml")]
+    [InlineData("v3.callback-example.json")]
+    [InlineData("v3.hubspot-events.json")]
+    [InlineData("v3.hubspot-webhooks.json")]
+    [InlineData("v3.ingram-micro.json")]
+    [InlineData("v3.link-example.yaml")]
+    [InlineData("v3.link-example.json")]
+    [InlineData("v3.petstore-expanded.yaml")]
+    [InlineData("v3.petstore-expanded.json")]
+    [InlineData("v3.petstore.yaml")]
+    [InlineData("v3.petstore.json")]
+    [InlineData("v3.uspto.yaml")]
+    [InlineData("v3.uspto.json")]
+    [InlineData("v3.no-content.yaml")]
+    [InlineData("v3.weather.json")]
+    public async Task ValidationRuleSet_Empty(string apiFile)
+    {
+        var folder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(folder);
+
+        var openapiFilename = Path.Combine(folder, apiFile);
+        var apiContents = EmbeddedResources.GetStream(apiFile);
+        await File.WriteAllTextAsync(openapiFilename, apiContents);
+        
+        var result = await OpenApiMultiFileReader.Read(openapiFilename, ValidationRuleSet.GetEmptyRuleSet());
+
+        result.OpenApiDiagnostic.Errors.Should().BeEmpty();
     }
 }

--- a/src/OasReader.Tests/Resources/v3/no-content.yaml
+++ b/src/OasReader.Tests/Resources/v3/no-content.yaml
@@ -5,8 +5,8 @@ info:
 paths:
   '/orders/{orderId}/order-items/{orderItemId}':
     parameters:
-      - $ref: '#/parameters/OrderId'
-      - $ref: '#/parameters/OrderItemId'
+      - $ref: '#/components/parameters/OrderId'
+      - $ref: '#/components/parameters/OrderItemId'
     delete:
       summary: Delete an order item
       description: >-
@@ -17,26 +17,26 @@ paths:
           description: No Content.
         default:
           description: Default response
-          schema:
-            $ref: '#/definitions/Error'
-definitions:
-  Error:
-    type: object
-    properties:
-      message:
-          type: string
-parameters:
-  OrderId:
-    name: orderId
-    in: path
-    description: Identifier of the order.
-    required: true
-    type: string
-    format: uuid
-  OrderItemId:
-    name: orderItemId
-    in: path
-    description: Identifier of the order item.
-    required: true
-    type: string
-    format: uuid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            
+components:
+  schemas:      
+    Error:
+      type: object
+      properties:
+        message:
+            type: string
+  parameters:
+    OrderId:
+      name: orderId
+      in: path
+      description: Identifier of the order.
+      required: true
+    OrderItemId:
+      name: orderItemId
+      in: path
+      description: Identifier of the order item.
+      required: true

--- a/src/OasReader.Tests/Resources/v3/weather.json
+++ b/src/OasReader.Tests/Resources/v3/weather.json
@@ -1,0 +1,103 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "WebApplication3",
+      "version": "1.0"
+    },
+    "paths": {
+      "/weatherforecast/{id}": {
+        "get": {
+          "tags": [
+            "WebApplication3"
+          ],
+          "operationId": "GetWeatherForecastById",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherForecast"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/weatherforecast/{code}": {
+        "get": {
+          "tags": [
+            "WebApplication3"
+          ],
+          "operationId": "GetWeatherForecastByCode",
+          "parameters": [
+            {
+              "name": "code",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherForecast"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "WeatherForecast": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date"
+            },
+            "temperatureC": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "summary": {
+              "type": "string",
+              "nullable": true
+            },
+            "temperatureF": {
+              "type": "integer",
+              "format": "int32",
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }

--- a/src/OasReader/OpenApiMultiFileReader.cs
+++ b/src/OasReader/OpenApiMultiFileReader.cs
@@ -1,19 +1,24 @@
 ﻿using System.Net;
 using System.Security;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
 
 namespace Microsoft.OpenApi.Readers;
 
 public static class OpenApiMultiFileReader
 {
-    public static async Task<Result> Read(string openApiFile, CancellationToken cancellationToken = default)
+    public static async Task<Result> Read(
+        string openApiFile,
+        ValidationRuleSet? validationRuleSet = default,
+        CancellationToken cancellationToken = default)
     {
         var directoryName = new FileInfo(openApiFile).DirectoryName;
         var openApiReaderSettings = new OpenApiReaderSettings
         {
             BaseUrl = openApiFile.StartsWith("http", StringComparison.OrdinalIgnoreCase)
                 ? new Uri(openApiFile)
-                : new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}")
+                : new Uri($"file://{directoryName}{Path.DirectorySeparatorChar}"),
+            RuleSet = validationRuleSet ?? ValidationRuleSet.GetEmptyRuleSet(),
         };
 
         using var stream = await GetStream(openApiFile);
@@ -73,7 +78,7 @@ public static class OpenApiMultiFileReader
 public class Result
 {
     public Result(
-        OpenApiDiagnostic openApiDiagnostic, 
+        OpenApiDiagnostic openApiDiagnostic,
         OpenApiDocument openApiDocument,
         bool containedExternalReferences)
     {


### PR DESCRIPTION
This pull request includes significant changes to the `OasReader` project, primarily focusing on adding validation rule sets and enhancing OpenAPI document handling. The most important changes include adding validation rule sets to the `OpenApiMultiFileReader`, updating test cases to validate OpenAPI documents using different rule sets, and modifying OpenAPI document examples to align with the latest specifications.

Enhancements to validation:

* [`src/OasReader/OpenApiMultiFileReader.cs`](diffhunk://#diff-1955dbb6b5b5cef31b3aefc6268138b1a7b7a0bca8410170cc6a481e44ba9412R4-R21): Added support for `ValidationRuleSet` to the `Read` method to allow validation of OpenAPI documents.

Updates to test cases:

* [`src/OasReader.Tests/OpenApiDocumentExtensionsTests.cs`](diffhunk://#diff-a449d9f5777dbf4eace85f0972774fe737070dc68958a084caf2b583d879955aR94-R156): Added new test cases to validate OpenAPI documents using the default and empty validation rule sets.

Modifications to OpenAPI document examples:

* [`src/OasReader.Tests/Resources/v3/no-content.yaml`](diffhunk://#diff-5cdd0fc3cfa6deb7412ba0a22af788d5bb92204b67293da5e75dd8e64f6d1400L8-R9): Updated references and components to align with the latest OpenAPI specifications. [[1]](diffhunk://#diff-5cdd0fc3cfa6deb7412ba0a22af788d5bb92204b67293da5e75dd8e64f6d1400L8-R9) [[2]](diffhunk://#diff-5cdd0fc3cfa6deb7412ba0a22af788d5bb92204b67293da5e75dd8e64f6d1400R20-R26) [[3]](diffhunk://#diff-5cdd0fc3cfa6deb7412ba0a22af788d5bb92204b67293da5e75dd8e64f6d1400L34-L42)
* [`src/OasReader.Tests/Resources/v3/weather.json`](diffhunk://#diff-8301d01b994b50231819eedfc2e17d79377a39c56ad4def0845a698bed6a97b5R1-R103): Added a new OpenAPI document example for weather forecasting, including paths, operations, and components.

Dependency updates:

* `src/OasReader.Tests/OpenApiDocumentExtensionsTests.cs` and `src/OasReader/OpenApiMultiFileReader.cs`: Added `Microsoft.OpenApi.Validations` to support validation rule sets. [[1]](diffhunk://#diff-a449d9f5777dbf4eace85f0972774fe737070dc68958a084caf2b583d879955aR4) [[2]](diffhunk://#diff-1955dbb6b5b5cef31b3aefc6268138b1a7b7a0bca8410170cc6a481e44ba9412R4-R21)